### PR TITLE
sonar frontend build test

### DIFF
--- a/.github/workflows/build_frontend.yml
+++ b/.github/workflows/build_frontend.yml
@@ -1,0 +1,19 @@
+name: Build
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  sonarqube:
+    name: SonarQube
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v6
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,15 @@
+sonar.projectKey=kroegerleif_Alfheim_frontend
+sonar.organization=kroegerleif
+
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectName=kroegerleif_Alfheim_frontend
+#sonar.projectVersion=1.0
+
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+sonar.sources=./frontend/src
+sonar.coverage.exclusions= ./frontend/src/**
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
This pull request introduces SonarQube integration for code quality analysis on the frontend. It adds a GitHub Actions workflow to trigger SonarQube scans on pushes to `master` and on pull request events, and configures the SonarQube project settings for the frontend source code.

**CI/CD Integration:**

* Added `.github/workflows/build_frontend.yml` to define a new GitHub Actions workflow named "Build" that runs SonarQube scans on relevant branch and PR events.

**SonarQube Configuration:**

* Created `sonar-project.properties` to specify SonarQube project key, organization, source directory, and coverage exclusions for the frontend codebase.