### PR TITLE
Home uses React Hook form now

### DIFF
--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -25,7 +25,7 @@ function HomePage(){
         <div className={"flex flex-col justify-center items-center"}>
             <div className={"flex flex-col justify-center items-center w-full"}>
                 <h1>Home Overview</h1>
-                <CreateNewHome/>
+                <CreateNewHome loadHomeData={loadHomeData}/>
             </div>
             <div className={"flex flex-row flex-wrap"}>
                 {


### PR DESCRIPTION
This pull request refactors the "Create New Home" form in the frontend to use `react-hook-form` for form state management, enhances the UI with custom field components, and improves the user experience by reloading home data after creation instead of redirecting. The changes also simplify the code by removing unused imports and state.

Form handling and state management improvements:

* Refactored `CreateNewHome` to use `react-hook-form` for form state and validation, replacing manual state management and input handlers.
* Updated the form submission logic to reload home data after a successful creation instead of redirecting the user, and improved error handling with toast notifications. [[1]](diffhunk://#diff-c3a5d755f9575cf108b3d4993aa566fd5990ae1cf1f941a32fdc1417328a6881L13-R69) [[2]](diffhunk://#diff-85c26b21681286c20e97a26a4912f0b91812776c9d4d0c54aa541fded2565c7eL28-R28)

UI and component enhancements:

* Replaced basic form layout with custom `Field`, `FieldLabel`, and `FieldSet` components for better structure and accessibility.
* Updated the dialog component to control its open state via React state, allowing the modal to close automatically after a successful submission.

Code cleanup:

* Removed unused imports and legacy code related to form state and navigation.